### PR TITLE
Fix Checkbox's Label search

### DIFF
--- a/SeleniumTesting/SeleniumTesting/Controls/CheckBox.cs
+++ b/SeleniumTesting/SeleniumTesting/Controls/CheckBox.cs
@@ -7,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Controls
         public Checkbox(ISearchContainer container, ISelector selector)
             : base(container, selector)
         {
-            Label = new Label(this, new UniversalSelector("*:nth-child(3)"));
+            Label = new Label(this, new UniversalSelector("*:first-child + * + *"));
         }
 
         public Label Label { get; private set; }


### PR DESCRIPTION
Почему-то у меня поиск Label в отмеченном чекбоксе стал указывать на иконку.
Почему так произошло, я пока не разобрался. 
Казалось бы, селектор nth-child работает для элементов, у которых есть n-1 **соседей** перед ним. Почему под него попадает иконка, которая находится на двух уровнях вложенности и не имеет соседей, непонятно.