### PR TITLE
Date picker improvements

### DIFF
--- a/SeleniumTesting/.vs/SeleniumTesting/v15/Server/sqlite3/.gitignore
+++ b/SeleniumTesting/.vs/SeleniumTesting/v15/Server/sqlite3/.gitignore
@@ -1,0 +1,4 @@
+/db.lock
+/storage.ide
+/storage.ide-shm
+/storage.ide-wal

--- a/SeleniumTesting/SeleniumTesting/Controls/DatePicker.cs
+++ b/SeleniumTesting/SeleniumTesting/Controls/DatePicker.cs
@@ -16,8 +16,13 @@ namespace SKBKontur.SeleniumTesting.Controls
             ExecuteAction(x =>
                 {
                     var element = x.FindElement(By.CssSelector("input"));
-                    element.SendKeys(Keys.Control + "a");
-                    element.SendKeys(Keys.Backspace);
+                    element.SendKeys(Keys.End);
+                    var length = element.GetAttribute("value").Length;
+                    while(length > 0)
+                    {
+                        element.SendKeys(Keys.Backspace);
+                        length--;
+                    }
                     element.SendKeys(Keys.Tab);
                 }, "Clear");
         }
@@ -51,6 +56,6 @@ namespace SKBKontur.SeleniumTesting.Controls
         }
 
         public string Value { get { return GetValueFromElement(x => container.ExecuteScript("return arguments[0].value", x.FindElement(By.CssSelector("input"))) as string); } }
-         public bool IsDisabled { get { return GetReactProp<bool>("disabled"); } }
-   }
+        public bool IsDisabled { get { return GetReactProp<bool>("disabled"); } }
+    }
 }

--- a/SeleniumTesting/TestPages/src/components/TestPages/DatePickerTestPage.jsx
+++ b/SeleniumTesting/TestPages/src/components/TestPages/DatePickerTestPage.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import Button from 'retail-ui/components/Button'
 import DatePicker from 'retail-ui/components/DatePicker'
-import { CaseSuite, Case } from '../Case';
+import {CaseSuite, Case} from '../Case';
 
 export default class DatePickerTestPage extends React.Component {
     state = {
-        simpleSelect1: null,
-        select2: null,
+        date1: '29.08.2016',
+        date2: '31.12.2017'
     };
 
     render(): React.Element<*> {
@@ -16,12 +15,31 @@ export default class DatePickerTestPage extends React.Component {
                     <Case.Body>
                         <DatePicker
                             data-tid='SimpleDatePicker'
-                            value={this.state.value} 
-                            onChange={(e, value) => this.setState({ value: value })}
+                            value={this.state.value}
+                            onChange={(e, value) => this.setState({value: value})}
                         />
                     </Case.Body>
                 </Case>
-           </CaseSuite>
+                <Case title='Дейтпикер с датой'>
+                    <Case.Body>
+                        <DatePicker
+                            data-tid='FilledDatePicker'
+                            value={this.state.date1}
+                            onChange={(e, value) => this.setState({date1: value})}
+                        />
+                    </Case.Body>
+                </Case>
+                <Case title='Задизабленный дейтпикер с датой'>
+                    <Case.Body>
+                        <DatePicker
+                            data-tid='DisabledDatePicker'
+                            value={this.state.date2}
+                            onChange={(e, value) => this.setState({date2: value})}
+                            disabled={true}
+                        />
+                    </Case.Body>
+                </Case>
+            </CaseSuite>
         );
     }
 }

--- a/SeleniumTesting/Tests/DatePickerTests/DatePickerTest.cs
+++ b/SeleniumTesting/Tests/DatePickerTests/DatePickerTest.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+
+using NUnit.Framework;
 
 namespace SKBKontur.SeleniumTesting.Tests.DatePickerTests
 {
@@ -20,6 +22,65 @@ namespace SKBKontur.SeleniumTesting.Tests.DatePickerTests
         public void TestPresence()
         {
             page.SimpleDatePicker.ExpectTo().BePresent();
+        }
+
+        [Test]
+        public void TestInputDateInEmpty()
+        {
+            page.SimpleDatePicker.ClearAndInputDate(new DateTime(2017, 11, 30, 12, 0, 0));
+            Assert.AreEqual("30.11.2017", page.SimpleDatePicker.Value);
+        }
+
+        [Test]
+        public void TestInputTextInEmpty()
+        {
+            page.SimpleDatePicker.ClearAndInputText("30.11.2017");
+            Assert.AreEqual("30.11.2017", page.SimpleDatePicker.Value);
+        }
+
+        [Test]
+        public void TestInputDateInFilled()
+        {
+            page.FilledDatePicker.ClearAndInputDate(new DateTime(2017, 11, 30, 12, 0, 0));
+            Assert.AreEqual("30.11.2017", page.FilledDatePicker.Value);
+        }
+
+        [Test]
+        public void TestInputTextInFilled()
+        {
+            page.FilledDatePicker.ClearAndInputText("30.11.2017");
+            Assert.AreEqual("30.11.2017", page.FilledDatePicker.Value);
+        }
+
+        [Test]
+        public void TestValueInFilled()
+        {
+            Assert.AreEqual("29.08.2016", page.FilledDatePicker.Value);
+        }
+
+        [Test]
+        public void TestClearFilled()
+        {
+            page.FilledDatePicker.Clear();
+            Assert.AreEqual(string.Empty, page.FilledDatePicker.Value);
+        }
+
+        [Test]
+        public void TestDisabled()
+        {
+            Assert.AreEqual(true, page.DisabledDatePicker.IsDisabled);
+        }
+
+        [Test]
+        public void TestNotDisabled()
+        {
+            Assert.AreEqual(false, page.FilledDatePicker.IsDisabled);
+        }
+
+        [Test]
+        public void TestValueInDisabled()
+        {
+            Assert.AreEqual("31.12.2017", page.DisabledDatePicker.Value);
         }
 
         private DatePickerTestPage page;

--- a/SeleniumTesting/Tests/DatePickerTests/DatePickerTestPage.cs
+++ b/SeleniumTesting/Tests/DatePickerTests/DatePickerTestPage.cs
@@ -14,5 +14,7 @@ namespace SKBKontur.SeleniumTesting.Tests.DatePickerTests
         }
 
         public DatePicker SimpleDatePicker { get; private set; }
+        public DatePicker FilledDatePicker { get; private set; }
+        public DatePicker DisabledDatePicker { get; private set; }
     }
 }


### PR DESCRIPTION
Оказалось, что с новым DatePicker из retail-ui очень плохо работает метод DatePicker.Clear(). Поправил метод, заодно написал тестов на контрол.