### PR TITLE
Поддержка sidepage

### DIFF
--- a/SeleniumTesting/SeleniumTesting/Controls/SidePageBase.cs
+++ b/SeleniumTesting/SeleniumTesting/Controls/SidePageBase.cs
@@ -1,0 +1,19 @@
+﻿using OpenQA.Selenium;
+
+using SKBKontur.SeleniumTesting.Internals.Selectors;
+
+namespace SKBKontur.SeleniumTesting.Controls
+{
+    public abstract class SidePageBase: Portal
+    {
+        protected SidePageBase(ISearchContainer container, ISelector selector)
+            : base(container, selector)
+        {
+        }
+
+        public void Close()
+        {
+            Search(new BySelector(By.LinkText("×"))).Click();
+        }
+    }
+}

--- a/SeleniumTesting/SeleniumTesting/SeleniumTesting.csproj
+++ b/SeleniumTesting/SeleniumTesting/SeleniumTesting.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Controls\MenuItem.cs" />
     <Compile Include="Controls\Paging.cs" />
     <Compile Include="Controls\PopupBase.cs" />
+    <Compile Include="Controls\SidePageBase.cs" />
     <Compile Include="IAndContraint.cs" />
     <Compile Include="Assertions\Bases\ControlBaseAssertions.cs" />
     <Compile Include="Assertions\Context\AssertionsContext.cs" />

--- a/SeleniumTesting/TestPages/package-lock.json
+++ b/SeleniumTesting/TestPages/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/react": {
-      "version": "16.0.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.31.tgz",
-      "integrity": "sha512-ft7OuDGUo39e+9LGwUewf2RyEaNBOjWbHUmD5bzjNuSuDabccE/1IuO7iR0dkzLjVUKxTMq69E+FmKfbgBcfbQ=="
+      "version": "16.0.34",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.34.tgz",
+      "integrity": "sha512-Ee66fX2qMsDnDq7sPnDtq1bGoo479j6Fo1BlSnne+L5rp6ndzBUgz72+MRNuN56zg9uuteRCkJAMdDJEX2Uqig=="
     },
     "accepts": {
       "version": "1.3.4",

--- a/SeleniumTesting/TestPages/src/ReactTestApplication.js
+++ b/SeleniumTesting/TestPages/src/ReactTestApplication.js
@@ -30,6 +30,12 @@ if (process.env.hasPaging)
 else
     PagingTestPage = () => <div>Does not work</div>;
 
+let SidePageTestPage;
+if(process.env.hasSidePage)
+    SidePageTestPage = require("./components/TestPages/SidePageTestPage").default;
+else
+    SidePageTestPage = () => <div>Does not work</div>;
+
 import './styles/reset.less';
 import './styles/typography.less';
 
@@ -54,6 +60,7 @@ export default function ReactTestApplication() {
                 <Route path='ExposeTidToDom' component={ExposeTidToDomTestPage} />
                 <Route path='Kebab' component={KebabTestPage} />
                 <Route path='Paging' component={PagingTestPage} />
+                <Route path='SidePage' component={SidePageTestPage}/>
             </Route>
         </Router>
     )

--- a/SeleniumTesting/TestPages/src/components/TestPages/SidePageTestPage.jsx
+++ b/SeleniumTesting/TestPages/src/components/TestPages/SidePageTestPage.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {Case, CaseSuite} from "../Case";
+import Button from "retail-ui/components/Button";
+import SidePage from "retail-ui/components/SidePage";
+
+export default class SidePageTestPage extends React.Component {
+    state = {
+        showStateless: false,
+        showStatefull: false
+    };
+
+    open = (name) => this.setState({[name]: true});
+    close = (name) => this.setState({[name]: false});
+
+    render = () => (
+        <CaseSuite title="Сайдпейджи">
+            <Case title="Сайдпейдж на stateless компоненте, принимающий свойство show">
+                <Case.Body>
+                    <Button
+                        data-tid='OpenStateless'
+                        onClick={() => this.open("showStateless")}
+                    >
+                        Открыть
+                    </Button>
+                    <StatelessSidePage
+                        data-tid="StatelessSidePage"
+                        show={this.state.showStateless}
+                        onClose={() => this.close("showStateless")}
+                    />
+                </Case.Body>
+            </Case>
+            <Case title="Сайдпейдж на statefull компоненте, принимающий свойство show">
+                <Case.Body>
+                    <Button
+                        data-tid="OpenStatefull"
+                        onClick={() => this.open("showStatefull")}
+                    >
+                        Открыть
+                    </Button>
+                    <StatefullSidePage
+                        data-tid="StatefullSidePage"
+                        show={this.state.showStatefull}
+                        onClose={() => this.close("showStatefull")}
+                    />
+                </Case.Body>
+            </Case>
+        </CaseSuite>
+    );
+}
+
+function StatelessSidePage({ show, onClose }) {
+    return show ? (
+        <SidePage onClose={onClose}>
+            <SidePage.Header>
+                <span data-tid="Header">Header</span>
+            </SidePage.Header>
+            <SidePage.Body>
+                <div data-tid="Content">
+                    Modal content
+                </div>
+            </SidePage.Body>
+            <SidePage.Footer>
+                <span data-tid="Footer">Footer</span>
+            </SidePage.Footer>
+        </SidePage>
+    ) : (
+        <span/>
+    );
+}
+
+class StatefullSidePage extends React.Component {
+    render() {
+        const {show, onClose} = this.props;
+        return show ? (
+            <SidePage onClose={onClose}>
+                <SidePage.Header>
+                    <span data-tid="Header">Header</span>
+                </SidePage.Header>
+                <SidePage.Body>
+                    <div data-tid="Content">
+                        Modal content
+                    </div>
+                </SidePage.Body>
+                <SidePage.Footer>
+                    <span data-tid="Footer">Footer</span>
+                </SidePage.Footer>
+            </SidePage>
+        ) : (
+            <span/>
+        )
+    }
+}

--- a/SeleniumTesting/TestPages/versions.js
+++ b/SeleniumTesting/TestPages/versions.js
@@ -1,14 +1,14 @@
 var shell = require("shelljs");
 var semver = require("semver");
 
-var versionsOutput = shell.exec("npm show retail-ui versions", { silent: true });
+var versionsOutput = shell.exec("npm show retail-ui versions --json", { silent: true });
 var retailUIVersions = eval(versionsOutput.stdout);
 
 const resultVersions = {
-    '16.0.0': '0.9.9 || >=0.10.8',
-    '15.3.0': '0.6.18 || 0.8.15 || 0.9.9 || >=0.10.8',
-    '15.4.2': '0.6.18 || 0.8.15 || 0.9.9 || >=0.10.8',
-    '0.14.3': '0.6.18 || 0.8.15 || 0.9.9 || >=0.10.8',
+    '16.0.0': '0.9.9 || >=0.11.0',
+    '15.3.0': '0.6.18 || 0.8.15 || 0.9.9 || >=0.11.0',
+    '15.4.2': '0.6.18 || 0.8.15 || 0.9.9 || >=0.11.0',
+    '0.14.3': '0.6.18 || 0.8.15 || 0.9.9 || >=0.11.0',
 };
 
 var result = {};
@@ -22,7 +22,7 @@ if (process.env["TEAMCITY_VERSION"]) {
 } else {
     result = {
         '16.0.0': ['0.9.7'],
-        "15.4.2": ["0.10.8"],
+        "15.4.2": ["0.11.0"],
     };
 }
 

--- a/SeleniumTesting/TestPages/webpack.config.js
+++ b/SeleniumTesting/TestPages/webpack.config.js
@@ -80,6 +80,7 @@ function createConfig(reactVersion, retailUIVersion, pairs) {
                 'process.env.enableReactTesting': JSON.stringify(true),
                 'process.env.hasKebab': JSON.stringify(semver.satisfies(retailUIVersion, '>=0.9.0')),
                 'process.env.hasPaging': JSON.stringify(semver.satisfies(retailUIVersion, '>=0.9.0')),
+                'process.env.hasSidePage': JSON.stringify(semver.satisfies(retailUIVersion, '>=0.11.0')),
                 'process.env.newCombobox': JSON.stringify(semver.satisfies(retailUIVersion, '>=0.7.0')),
                 'process.env.retailUIVersion': JSON.stringify(retailUIVersion),
                 'process.env.baseUrl': JSON.stringify('/' + reactVersion + '/' + retailUIVersion),

--- a/SeleniumTesting/Tests/SidePages/SidePageTestPage.cs
+++ b/SeleniumTesting/Tests/SidePages/SidePageTestPage.cs
@@ -1,0 +1,42 @@
+﻿using OpenQA.Selenium.Remote;
+
+using SKBKontur.SeleniumTesting.Controls;
+using SKBKontur.SeleniumTesting.Tests.AutoFill;
+
+namespace SKBKontur.SeleniumTesting.Tests.SidePages
+{
+    [AutoFillControls]
+    public class SidePageTestPage: PageBase
+    {
+        public SidePageTestPage(RemoteWebDriver webDriver)
+            : base(webDriver)
+        {
+        }
+
+        public Button OpenStateless { get; set; }
+
+        public TestSidePage StatelessSidePage { get; set; }
+
+        public Button OpenStatefull { get; set; }
+
+        public TestSidePage StatefullSidePage { get; set; }
+
+        [AutoFillControls]
+        public class TestSidePage : SidePageBase
+        {
+            public TestSidePage(ISearchContainer container, ISelector selector)
+                : base(container, selector)
+            {
+            }
+
+            [Selector("##Header")]
+            public Label Header { get; set; }
+
+            [Selector("##Content")]
+            public Label Content { get; set; }
+
+            [Selector("##Footer")]
+            public Label Footer { get; set; }
+        }
+    }
+}

--- a/SeleniumTesting/Tests/SidePages/SidePageTests.cs
+++ b/SeleniumTesting/Tests/SidePages/SidePageTests.cs
@@ -1,0 +1,46 @@
+﻿using NUnit.Framework;
+
+using SKBKontur.SeleniumTesting.Tests.Helpers;
+using SKBKontur.SeleniumTesting.Tests.TestEnvironment;
+
+namespace SKBKontur.SeleniumTesting.Tests.SidePages
+{
+    [DefaultWaitInterval(5000)]
+    public class SidePageTests: TestBase
+    {
+        public SidePageTests(string reactVersion, string retailUiVersion)
+            : base(reactVersion, retailUiVersion, "0.11.0")
+        {
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            page = OpenUrl("SidePage").GetPageAs<SidePageTestPage>();
+        }
+
+        [Test]
+        public void Test_Stateless_OpenAndClose()
+        {
+            page.OpenStateless.Click();
+            page.StatelessSidePage.IsPresent.Wait().That(Is.True);
+            page.StatelessSidePage.Header.Text.Wait().That(Is.EqualTo("Header"));
+
+            page.StatelessSidePage.Close();
+            page.StatelessSidePage.IsPresent.Wait().That(Is.False);
+        }
+
+        [Test]
+        public void Test_Statefull_OpenAndClose()
+        {
+            page.OpenStatefull.Click();
+            page.StatefullSidePage.IsPresent.Wait().That(Is.True);
+            page.StatefullSidePage.Header.Text.Wait().That(Is.EqualTo("Header"));
+
+            page.StatefullSidePage.Close();
+            page.StatefullSidePage.IsPresent.Wait().That(Is.False);
+        }
+
+        private SidePageTestPage page;
+    }
+}

--- a/SeleniumTesting/Tests/TestEnvironment/TestBase.cs
+++ b/SeleniumTesting/Tests/TestEnvironment/TestBase.cs
@@ -5,7 +5,7 @@ using SKBKontur.SeleniumTesting.Tests.Helpers;
 
 namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
 {
-    [TestFixture("15.4.2", "0.10.8")]
+    [TestFixture("15.4.2", "0.11.0")]
     //[TestFixture("16.0.0", "0.9.7")]
     [TestFixtureSource(typeof(RetailUIAndReactVersions))]
     public abstract class TestBase

--- a/SeleniumTesting/Tests/Tests.csproj
+++ b/SeleniumTesting/Tests/Tests.csproj
@@ -61,6 +61,8 @@
     <Compile Include="AutoFill\ChildSelectorAttribute.cs" />
     <Compile Include="AutoFill\SelectorAttribute.cs" />
     <Compile Include="AutoFill\SkipAutoFillAttribute.cs" />
+    <Compile Include="SidePages\SidePageTestPage.cs" />
+    <Compile Include="SidePages\SidePageTests.cs" />
     <Compile Include="TestEnvironment\PathUtils.cs" />
     <Compile Include="TestEnvironment\ProcessUtils.cs" />
     <Compile Include="TestEnvironment\RetailUIAndReactVersions.cs" />


### PR DESCRIPTION
Обвязка и пара тестов для SidePage

+ маленький бонус: с выходом 0.11.0 версии пакета retail-ui команда `npm show retail-ui versions` из файлика versions.js начала возвращать не массив строк, а добавлять в конце `... 1 more item ]`. Параметр `--json` это починил