### PR TITLE
Исключение иконки из текста ссылок

### DIFF
--- a/SeleniumTesting/SeleniumTesting/Controls/Link.cs
+++ b/SeleniumTesting/SeleniumTesting/Controls/Link.cs
@@ -4,13 +4,26 @@ namespace SKBKontur.SeleniumTesting.Controls
 {
     public class Link : ControlBase
     {
+        private const string Script = "var link = arguments[0];" +
+                                      "var hasIcon = link.firstChild &&" +
+                                      "              link.firstChild.firstChild &&" +
+                                      "              link.firstChild.firstChild.getAttribute('data-comp-name') === 'Icon';" +
+                                      "" +
+                                      "if (!hasIcon) {" +
+                                      "    return link.innerText;" +
+                                      "}" +
+                                      "" +
+                                      "var clone = link.cloneNode(true);" +
+                                      "clone.removeChild(clone.firstChild);" +
+                                      "return clone.innerText;";
+
         public Link(ISearchContainer container, ISelector selector)
             : base(container, selector)
         {
         }
 
-        public IProp<bool> IsDisabled => ReactProperty<bool>("disabled", null);
+        public IProp<bool> IsDisabled => ReactProperty<bool>("disabled");
         public IProp<string> Url => ValueFromElement(element => element.GetAttribute("href"));
-        public IProp<string> Text => ValueFromElement(element => element.Text);
+        public IProp<string> Text => ValueFromElement(element => (string) ExecuteScript(Script, element));
     }
 }

--- a/SeleniumTesting/TestPages/src/components/TestPages/LinkTestPage.jsx
+++ b/SeleniumTesting/TestPages/src/components/TestPages/LinkTestPage.jsx
@@ -20,6 +20,41 @@ export default class LinkTestPage extends React.Component {
                         </Link>
                     </Case.Body>
                 </Case>
+                <Case title='Disabled Link'>
+                    <Case.Body>
+                        <Link
+                            href='#'
+                            data-tid='DisabledLink'
+                            disabled
+                        >
+                            Disabled link
+                        </Link>
+                    </Case.Body>
+                </Case>
+                <Case title='Iconic Link'>
+                    <Case.Body>
+                        <Link
+                            href='#'
+                            data-tid='IconicLink'
+                            icon='Add'
+                        >
+                            Iconic link
+                        </Link>
+                    </Case.Body>
+                </Case>
+                <Case title='Iconic Link Complex'>
+                    <Case.Body>
+                        <Link
+                            href='#'
+                            data-tid='IconicLinkComplex'
+                            icon='USB'
+                        >
+                            <span>prefix</span>
+                            text
+                            <span>suffix</span>
+                        </Link>
+                    </Case.Body>
+                </Case>
            </CaseSuite>
         );
     }

--- a/SeleniumTesting/Tests/Helpers/AssertionExtensions.cs
+++ b/SeleniumTesting/Tests/Helpers/AssertionExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Kontur.RetryableAssertions.Configuration;
 using Kontur.RetryableAssertions.ValueProviding;
 using Kontur.Selone.Properties;
-
+using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
 using OpenQA.Selenium;
@@ -44,6 +44,21 @@ namespace SKBKontur.SeleniumTesting.Tests.Helpers
         public static void Assert<T>(this T value, IResolveConstraint constraint, string message = null)
         {
             NUnit.Framework.Assert.That(value, new ReusableConstraint(constraint), message);
+        }
+
+        public static IAssertionResult<T, TSource> EqualTo<T, TSource>(this IValueProvider<T, TSource> provider, T expected)
+        {
+            return provider.That(Is.EqualTo(expected));
+        }
+
+        public static IAssertionResult<bool, TSource> True<TSource>(this IValueProvider<bool, TSource> provider)
+        {
+            return provider.EqualTo(true);
+        }
+
+        public static IAssertionResult<bool, TSource> False<TSource>(this IValueProvider<bool, TSource> provider)
+        {
+            return provider.EqualTo(false);
         }
     }
 }

--- a/SeleniumTesting/Tests/LinkTests/LinkTest.cs
+++ b/SeleniumTesting/Tests/LinkTests/LinkTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-
+using SKBKontur.SeleniumTesting.Tests.Helpers;
 using SKBKontur.SeleniumTesting.Tests.TestEnvironment;
 
 namespace SKBKontur.SeleniumTesting.Tests.LinkTests
@@ -22,6 +22,32 @@ namespace SKBKontur.SeleniumTesting.Tests.LinkTests
         public void TestPresence()
         {
             page.SimpleLink.ExpectTo().BePresent();
+            page.SimpleLink.IsPresent.Wait().True();
+        }
+
+        [Test]
+        public void TestDisabled()
+        {
+                page.SimpleLink.IsDisabled.Wait().False();
+                page.DisabledLink.IsDisabled.Wait().True();
+        }
+
+        [Test]
+        public void TestTextWithoutIcon()
+        {
+                page.SimpleLink.Text.Wait().EqualTo("Simple link");
+        }
+
+        [Test]
+        public void TestTextWithIcon()
+        {
+                page.IconicLink.Text.Wait().EqualTo("Iconic link");
+        }
+
+        [Test]
+        public void TestComplextHtmlTextWithIcon()
+        {
+                page.IconicLinkComplex.Text.Wait().EqualTo("prefixtextsuffix");
         }
 
         private LinkTestPage page;

--- a/SeleniumTesting/Tests/LinkTests/LinkTestPage.cs
+++ b/SeleniumTesting/Tests/LinkTests/LinkTestPage.cs
@@ -14,5 +14,8 @@ namespace SKBKontur.SeleniumTesting.Tests.LinkTests
         }
 
         public Link SimpleLink { get; private set; }
+        public Link DisabledLink { get; private set; }
+        public Link IconicLink { get; private set; }
+        public Link IconicLinkComplex { get; private set; }
     }
 }


### PR DESCRIPTION
Если в ссылку передан проп icon то внутри ссылки появляется span с символом иконки и при получении текста ссылки, символ иконки тоже захватывается и затрудняет проверку текста.
Идея заключается в том чтобы избавляться от символа иконки, и есть несколько путей решения:

Как понимать что есть иконка:
 - **смотреть на структуру верстки и искать span с простой** - рабочий вариант
 - *смотреть на наличие пропа icon* - тогда нужно дописывать конфиг для прокидывания пропсов в верстку, и делать это на стороне продукта, так то тоже неплохой вариант
 - *смотреть на первый символ строки и проверять его по коду* - не понятно какие коды у иконок и они могут меняться, могут добавляться новые, плохой вариант

Где реализовать логику:
 - **на стороне браузера** - в этом случае WebDriver сделает только один HTTP запрос к браузеру и получит результат
 - *в C# коде* - понадобится либо несколько запросов к браузеру, либо одним запросом получаем всю верстку и парсим HTML на C#

Как как реализовать логику:
 - **вырезать кусок верстки до получения текста** - кажется более естественным способом: вырезать узел из DOM и получить innerText.
 - *получать текст и вырезать из него символ* - тоже можно, но первый вариант субъективно кажется правильнее

Все же есть сомнения по поводу того как лучше определять факт наличия иконки: через структуру верстки или через наличие пропа icon?

Есть еще принципиально другой вариант решения проблемы: изменить структуру компонента Link, чтобы его контент всегда оборачивался в какой-то тэг, тогда текст можно будет просто извлекать из него, но тогда получается, что верстка контролов подстраивается под тестирование, что кажется неправильным